### PR TITLE
add as.data.frame() to fix error

### DIFF
--- a/mixed_martial_arts/mma_chisquared/index.qmd
+++ b/mixed_martial_arts/mma_chisquared/index.qmd
@@ -594,13 +594,14 @@ data2 <- mma |>
 We again visualize the data.  We quickly observe that there is not a lot of data for the two lightest weight classes, atomweight and strawweight.  In fact, neither category had a fight which did not end in decision.
 
 ```{r, warning=FALSE}
-
 mosaicplot(~ decision + wtClass, data = data2,
            main = "",
            xlab = "Decision",
            ylab = "Weight Class",
-           color = c("tomato", "steelblue", "seagreen", "goldenrod"))
-
+           color = c("tomato", "steelblue", "seagreen", "goldenrod"), 
+           las = 1, # rotate labels horizontal
+           cex.axis = 0.8 # resize labels
+           )
 ```
 
 

--- a/mixed_martial_arts/mma_chisquared/mma_index.qmd
+++ b/mixed_martial_arts/mma_chisquared/mma_index.qmd
@@ -545,7 +545,10 @@ mosaicplot(~ decision + wtClass, data = data2,
            main = "",
            xlab = "Decision",
            ylab = "Weight Class",
-           color = c("tomato", "steelblue", "seagreen", "goldenrod"))
+           color = c("tomato", "steelblue", "seagreen", "goldenrod"), 
+           las = 1, # rotate labels horizontal
+          # cex.axis = 0.8 # resize labels
+           )
 ```
 
 

--- a/mixed_martial_arts/mma_chisquared/mma_index.qmd
+++ b/mixed_martial_arts/mma_chisquared/mma_index.qmd
@@ -383,10 +383,38 @@ d. Based on the contingency table, does there appear to be a meaningful associat
 A Mosaic plot visualizes the contingency table using rectangles with widths proportional to the counts for each category or combination of categories. 
 
 ```{r, warning=FALSE}
-library(ggmosaic)
-ggplot(data1) + 
-  geom_mosaic(aes(x = product(wtClass, decision), fill = wtClass)) +
-  xlab('Decision')
+# library(ggmosaic)
+# data1 = data1 %>% as.data.frame()
+# ggplot(data1) + 
+#   geom_mosaic(aes(x = product(wtClass, decision), fill = wtClass)) #+
+#   xlab('Decision')
+
+mosaicplot(table(data1$decision, data1$wtClass), 
+           color = TRUE, 
+           xlab = "Decision", 
+           ylab = "Weight Class",
+           main = "")
+
+# this works two but with label of decision and KO/TKO/Submission in the label
+# data1 |>
+#   count(wtClass, decision) |>
+#   group_by(wtClass) |>
+#   mutate(
+#     ymax = cumsum(n) / sum(n),
+#     ymin = lag(ymax, default = 0)
+#   ) |>
+#   ungroup() |>
+#   left_join(x_pos, by = "wtClass") |>
+#   ggplot(aes(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax, fill = decision)) +
+#   geom_rect(color = "white", linewidth = 1) +
+#   scale_x_continuous(
+#     breaks = x_pos$xmin + (x_pos$xmax - x_pos$xmin) / 2,
+#     labels = x_pos$wtClass
+#   ) +
+#   scale_y_continuous(labels = scales::percent) +
+#   labs(x = "Weight Class", y = "Proportion", fill = "Decision") +
+#   theme_minimal()
+
 ```
 
 ::: {.callout-note  title="Exercise 4"}
@@ -540,10 +568,15 @@ data2 <- mma |>
 We again visualize the data.  We quickly observe that there is not a lot of data for the two lightest weight classes, atomweight and strawweight.  In fact, neither category had a fight which did not end in decision.
 
 ```{r, warning=FALSE}
-library(ggmosaic)
-ggplot(data2) + 
-  geom_mosaic(aes(x = product(wtClass, decision), fill = wtClass)) +
-  xlab('Decision')
+# library(ggmosaic)
+# ggplot(data2) + 
+#   geom_mosaic(aes(x = product(wtClass, decision), fill = wtClass)) +
+#   xlab('Decision')
+mosaicplot(table(data2$decision, data2$wtClass),
+           color = TRUE,
+           xlab = "Decision",
+           ylab = "Weight Class",
+           main = "")
 ```
 
 
@@ -620,10 +653,15 @@ table(data3$wtClass, data3$decision)
 ```
 
 ```{r, warning=FALSE}
-library(ggmosaic)
-ggplot(data3) + 
-  geom_mosaic(aes(x = product(wtClass, decision), fill = wtClass)) +
-  xlab('Decision')
+# library(ggmosaic)
+# ggplot(data3) + 
+#   geom_mosaic(aes(x = product(wtClass, decision), fill = wtClass)) +
+#   xlab('Decision')
+mosaicplot(table(data3$decision, data3$wtClass),
+           color = TRUE,
+           xlab = "Decision",
+           ylab = "Weight Class",
+           main = "")
 ```
 
 ::: {.callout-note  title="Exercise 7"}

--- a/mixed_martial_arts/mma_chisquared/mma_index.qmd
+++ b/mixed_martial_arts/mma_chisquared/mma_index.qmd
@@ -383,38 +383,11 @@ d. Based on the contingency table, does there appear to be a meaningful associat
 A Mosaic plot visualizes the contingency table using rectangles with widths proportional to the counts for each category or combination of categories. 
 
 ```{r, warning=FALSE}
-# library(ggmosaic)
-# data1 = data1 %>% as.data.frame()
-# ggplot(data1) + 
-#   geom_mosaic(aes(x = product(wtClass, decision), fill = wtClass)) #+
-#   xlab('Decision')
-
-mosaicplot(table(data1$decision, data1$wtClass), 
-           color = TRUE, 
-           xlab = "Decision", 
-           ylab = "Weight Class",
-           main = "")
-
-# this works two but with label of decision and KO/TKO/Submission in the label
-# data1 |>
-#   count(wtClass, decision) |>
-#   group_by(wtClass) |>
-#   mutate(
-#     ymax = cumsum(n) / sum(n),
-#     ymin = lag(ymax, default = 0)
-#   ) |>
-#   ungroup() |>
-#   left_join(x_pos, by = "wtClass") |>
-#   ggplot(aes(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax, fill = decision)) +
-#   geom_rect(color = "white", linewidth = 1) +
-#   scale_x_continuous(
-#     breaks = x_pos$xmin + (x_pos$xmax - x_pos$xmin) / 2,
-#     labels = x_pos$wtClass
-#   ) +
-#   scale_y_continuous(labels = scales::percent) +
-#   labs(x = "Weight Class", y = "Proportion", fill = "Decision") +
-#   theme_minimal()
-
+mosaicplot(~ wtClass + decision , data = data1,
+           main = "",
+           ylab = "Decision",
+           xlab = "Weight Class",
+           color = c("tomato", "steelblue"))
 ```
 
 ::: {.callout-note  title="Exercise 4"}
@@ -568,15 +541,11 @@ data2 <- mma |>
 We again visualize the data.  We quickly observe that there is not a lot of data for the two lightest weight classes, atomweight and strawweight.  In fact, neither category had a fight which did not end in decision.
 
 ```{r, warning=FALSE}
-# library(ggmosaic)
-# ggplot(data2) + 
-#   geom_mosaic(aes(x = product(wtClass, decision), fill = wtClass)) +
-#   xlab('Decision')
-mosaicplot(table(data2$decision, data2$wtClass),
-           color = TRUE,
+mosaicplot(~ decision + wtClass, data = data2,
+           main = "",
            xlab = "Decision",
            ylab = "Weight Class",
-           main = "")
+           color = c("tomato", "steelblue", "seagreen", "goldenrod"))
 ```
 
 
@@ -653,15 +622,14 @@ table(data3$wtClass, data3$decision)
 ```
 
 ```{r, warning=FALSE}
-# library(ggmosaic)
-# ggplot(data3) + 
-#   geom_mosaic(aes(x = product(wtClass, decision), fill = wtClass)) +
-#   xlab('Decision')
-mosaicplot(table(data3$decision, data3$wtClass),
-           color = TRUE,
+mosaicplot(~ decision + wtClass, data = data3,
+           main = "",
            xlab = "Decision",
            ylab = "Weight Class",
-           main = "")
+           color = c("tomato", "steelblue", "seagreen", "goldenrod", "orchid", "sienna"),
+           las = 1, # rotate labels horizontal
+           cex.axis = 0.8 # resize labels
+           )
 ```
 
 ::: {.callout-note  title="Exercise 7"}

--- a/mixed_martial_arts/mma_interrater_reliability/index.qmd
+++ b/mixed_martial_arts/mma_interrater_reliability/index.qmd
@@ -2143,7 +2143,7 @@ F_conf_int <- Fleiss %>% select(Collett, Lethaby, Cartlidge) %>%
   KappaM(method = "Fleiss", conf.level = .95) %>% as_tibble() %>% pull() %>%
   round(digits = 3)
 
-F_indiv <- Fleiss %>% select(Collett, Lethaby, Cartlidge) %>% kappam.fleiss(detail = TRUE)
+F_indiv <- Fleiss %>% select(Collett, Lethaby, Cartlidge) %>% as.data.frame() %>% kappam.fleiss(detail = TRUE)
 ```
 
 After evaluating, we end up with a $p_{o}$ = `r F_prop_obs`. This is our total observed agreement. It includes both real agreement and chance agreement.
@@ -2294,6 +2294,7 @@ stu_F_conf_int <- stu_Fleiss %>% select(-fight, -fighter1, -fighter2, -draw) %>%
 
 stu_F_indiv <- stu_Fleiss %>%
   select(-fight, -fighter1, -fighter2, -draw) %>%
+  as.data.frame() %>%
   kappam.fleiss(detail = TRUE)
 
 stu_F_indiv_table <- as.data.frame.matrix(stu_F_indiv$detail) %>%


### PR DESCRIPTION
Fix 1
The `kappam.fleiss` function was failing. Adding `as.data.frame()` before it fixed it. I guess it doesn't like tibbles. 

Fix 2
Convert `ggmosaic` to `mosaicplot`. `ggmosaic` is no longer on CRAN and it apparently has a known bug related to new versions of `ggplot2`. I tried the GitHub version using

```
# install.packages("devtools")
devtools::install_github("haleyjeppson/ggmosaic")
```

and that didn't work either. 

It seems like two options are 

- Install an older version of ggplot2 or 
- change to base R. 
 
Using an older version of `ggplot2` seemed like a worse idea, so here is some example code for changing to base R. I implemented the base R version for all three plots. I kept the old code commented in case the authors or editors want to revert back using a different approach. Authors/editors may want to delete the commented code before publishing if they are ok with the new base R code.
